### PR TITLE
Add collapsible navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,13 @@
  h2{color:var(--teal);margin-top:0.5rem}
  canvas{max-width:100%;height:380px;margin:1rem 0;border:1px solid #ddd;border-radius:6px;background:#fff}
  .caption{font-size:.85rem;margin-top:-.5rem;color:#555;text-align:center}
- nav{position:fixed;bottom:1rem;right:1rem;display:flex;flex-direction:column;gap:.4rem;z-index:10}
- nav button{padding:.5rem .8rem;border:none;border-radius:5px;background:var(--teal);color:#fff;cursor:pointer;font-size:.9rem}
- nav button:focus{outline:2px dashed #fff;outline-offset:2px}
+nav{position:fixed;bottom:1rem;right:1rem;display:flex;flex-direction:column;gap:.4rem;z-index:10}
+nav button{padding:.5rem .8rem;border:none;border-radius:5px;background:var(--teal);color:#fff;cursor:pointer;font-size:.9rem}
+nav button:focus{outline:2px dashed #fff;outline-offset:2px}
+/* collapsed navigation */
+#navToggle{display:none}
+nav.collapsed button:not(#navToggle){display:none}
+nav.collapsed #navToggle{display:block}
  footer{background:#e1e4e3;padding:1.5rem 1rem;font-size:.9rem}
  footer h2{margin-top:0}
  ol{padding-left:1.2rem}
@@ -111,12 +115,14 @@
 </footer>
 
 <!-- Simple vertical navigation -->
-<nav aria-label="Section navigation">
+<nav aria-label="Section navigation" id="mainNav">
+ <button id="navToggle" onclick="showNav()" aria-label="Show navigation">🧭</button>
  <button onclick="jump('intro')">Urban Surge</button>
  <button onclick="jump('drivers')">Drivers</button>
  <button onclick="jump('pivot')">Tech Pivot</button>
  <button onclick="jump('future')">Future</button>
  <button onclick="jump('call')">Act Now</button>
+ <button onclick="hideNav()">Hide Navigation</button>
 </nav>
 
 <!-- narration player removed -->
@@ -222,6 +228,14 @@ updateChart();
 /* helper for side-nav buttons */
 function jump(id) {
   document.getElementById(id).scrollIntoView({ behavior: 'smooth' });
+}
+
+function hideNav() {
+  document.getElementById('mainNav').classList.add('collapsed');
+}
+
+function showNav() {
+  document.getElementById('mainNav').classList.remove('collapsed');
 }
 </script>
 


### PR DESCRIPTION
## Summary
- allow the navigation bar to collapse
- add a hide button with 🧭 icon for collapsed view

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b64cc71b8833399e065387012fed3